### PR TITLE
job #8949 removed whitespace from end of bodies to remove diffs for r…

### DIFF
--- a/masl/SAC/SAC_OOA/Session_Session_Established.al
+++ b/masl/SAC/SAC_OOA/Session_Session_Established.al
@@ -19,5 +19,4 @@ begin
    the_session_spec := find_one Session_Specification();
    schedule this.session_heartbeat_timer generate Session.heartbeat_timeout_expired() to this 
                         delay the_session_spec.session_heartbeat_time;
-
 end state;

--- a/masl/SAC/SAC_OOA/Session_Session_Heartbeat_Failed.al
+++ b/masl/SAC/SAC_OOA/Session_Session_Heartbeat_Failed.al
@@ -13,6 +13,4 @@ begin
       schedule this.session_heartbeat_timer generate Session.heartbeat_timeout_expired() to this 
                         delay the_session_spec.session_heartbeat_time;
    end if;
-   
-   
 end state;

--- a/masl/SAC/SAC_OOA/Session_Session_Timed_Out.al
+++ b/masl/SAC/SAC_OOA/Session_Session_Timed_Out.al
@@ -18,5 +18,4 @@ begin
       Operator~>report_user(the_user.user_id, the_user.login_name, 
                             the_user.user_name, the_user.is_logged_on);
    end if;
-   
 end state;

--- a/masl/SAC/SAC_OOA/Session_delete_session.svc
+++ b/masl/SAC/SAC_OOA/Session_delete_session.svc
@@ -50,5 +50,4 @@ begin
                                 the_user.user_name, the_user.is_logged_on);
       end if;
    end if;
-   
 end service;

--- a/masl/SAC/SAC_OOA/System_Configuration_get_groups.tr
+++ b/masl/SAC/SAC_OOA/System_Configuration_get_groups.tr
@@ -28,6 +28,5 @@ begin
       groups := groups & (the_group_name, operation_names);
       operation_names := empty_operation_names;
       the_indexed_data := empty_indexed_data;
-   end loop;   
-   
+   end loop;
 end service;

--- a/masl/SAC/SAC_OOA/System_Configuration_get_session_specification.tr
+++ b/masl/SAC/SAC_OOA/System_Configuration_get_session_specification.tr
@@ -13,6 +13,5 @@ begin
             heartbeat_failure_threshold := integer'parse(a_name_value.value);
          end if;
       end loop;
-   end loop;   
-   
+   end loop;
 end service;

--- a/masl/SAC/SAC_OOA/System_Configuration_reload_config_files.tr
+++ b/masl/SAC/SAC_OOA/System_Configuration_reload_config_files.tr
@@ -2,5 +2,4 @@ private service SAC::System_Configuration~>reload_config_files () is
 begin
    
    INI::reload_ini_files();
-   
 end service;

--- a/masl/SAC/SAC_OOA/add_group.svc
+++ b/masl/SAC/SAC_OOA/add_group.svc
@@ -8,5 +8,4 @@ begin
       the_group := create unique Group(group_name => group_name);
       Operator~>report_group(group_name);
    end if;
-   
 end service;

--- a/masl/SAC/SAC_OOA/add_operation_to_group.svc
+++ b/masl/SAC/SAC_OOA/add_operation_to_group.svc
@@ -25,5 +25,4 @@ begin
          Operator~>report_group_operation(group_name, an_operation);
       end if;
    end loop;
-   
 end service;

--- a/masl/SAC/SAC_OOA/delete_group.svc
+++ b/masl/SAC/SAC_OOA/delete_group.svc
@@ -14,5 +14,4 @@ begin
          delete the_group_operation;
       end loop;
    end if;
-   
 end service;

--- a/masl/SAC/SAC_OOA/delete_group_operation.svc
+++ b/masl/SAC/SAC_OOA/delete_group_operation.svc
@@ -22,5 +22,4 @@ begin
          end if;
       end loop;
    end if;
-   
 end service;

--- a/masl/SAC/SAC_OOA/populate_domain.svc
+++ b/masl/SAC/SAC_OOA/populate_domain.svc
@@ -99,5 +99,4 @@ begin
          end if;
       end loop;
    end loop;
-   
 end service;

--- a/masl/SAC/SAC_OOA/populate_domain_1.scn
+++ b/masl/SAC/SAC_OOA/populate_domain_1.scn
@@ -2,5 +2,4 @@ private service SAC::populate_domain_1 () is
 begin
    
    SAC::populate_domain(false);
-   
 end service;

--- a/masl/SAC/SAC_OOA/resend_infos.svc
+++ b/masl/SAC/SAC_OOA/resend_infos.svc
@@ -46,5 +46,4 @@ begin
       end loop;
    
    end loop;
-   
 end service;

--- a/masl/SAC/SAC_OOA/resend_infos_3.scn
+++ b/masl/SAC/SAC_OOA/resend_infos_3.scn
@@ -2,5 +2,4 @@ private service SAC::resend_infos_3 () is
 begin
    
    SAC::resend_infos();
-   
 end service;

--- a/masl/SAC/SAC_OOA/session_active.svc
+++ b/masl/SAC/SAC_OOA/session_active.svc
@@ -14,5 +14,4 @@ begin
       console << "SAC::session-active - Invalid session active received, session_id = " << session_id'image  << 
                  ", uid = " << user_id'image << ", sid = " << login_name << endl << flush;
    end if;
-   
 end service;

--- a/masl/SAC/SAC_OOA/soa_subscribe_2.scn
+++ b/masl/SAC/SAC_OOA/soa_subscribe_2.scn
@@ -14,5 +14,4 @@ begin
   SOA::subscribe("SAC_populate_domain");
   soa_messages := empty_soa_messages & "I_DCP_resend_infos";
   SOA::subscribe("SAC_resend_infos", soa_messages);
-
 end service;

--- a/masl/SAC/SAC_OOA/test_SAC_1.ext
+++ b/masl/SAC/SAC_OOA/test_SAC_1.ext
@@ -264,5 +264,4 @@ begin
    
    Test::print_results();
    Process::requestShutdown();
-   
 end service;

--- a/masl/SAC/SAC_OOA/user_logoff.svc
+++ b/masl/SAC/SAC_OOA/user_logoff.svc
@@ -20,5 +20,4 @@ begin
       console << "SAC::user_logoff - Invalid logoff received, session_id = " << session_id'image  << 
                  ", uid = " << user_id'image << ", sid = " << login_name << endl << flush;
    end if;
-   
 end service;

--- a/masl/SAC/SAC_OOA/user_logon.svc
+++ b/masl/SAC/SAC_OOA/user_logon.svc
@@ -87,5 +87,4 @@ begin
       Operator~>raise_notification(message, "Info");
       Operator~>login_valid(-1, user_id, false, "Invalid group specified", workstation_hostname, login_name);
    end if;
-   
 end service;

--- a/masl/SAC/SAC_PROC/SAC_Operator_group_deleted.tr
+++ b/masl/SAC/SAC_PROC/SAC_Operator_group_deleted.tr
@@ -9,5 +9,4 @@ private service SAC::Operator~>group_deleted (group_name : in  string) is
 begin
    
    I_DC::info_delete_Group(group_name);
-   
 end service;

--- a/masl/SAC/SAC_PROC/SAC_Operator_group_operation_removed.tr
+++ b/masl/SAC/SAC_PROC/SAC_Operator_group_operation_removed.tr
@@ -10,5 +10,4 @@ private service SAC::Operator~>group_operation_removed (group_name     : in  str
 begin
    
    I_DC::info_delete_Group_Operation(group_name, operation_name);
-   
 end service;

--- a/masl/SAC/SAC_PROC/SAC_Operator_login_valid.tr
+++ b/masl/SAC/SAC_PROC/SAC_Operator_login_valid.tr
@@ -14,5 +14,4 @@ private service SAC::Operator~>login_valid (session_id           : in  integer,
 begin
    
    I_ODGUI::login_valid(user_id, session_id, is_valid, failure_reason, workstation_hostname, login_name);
-   
 end service;

--- a/masl/SAC/SAC_PROC/SAC_Operator_raise_notification.tr
+++ b/masl/SAC/SAC_PROC/SAC_Operator_raise_notification.tr
@@ -10,5 +10,4 @@ private service SAC::Operator~>raise_notification (condition_description : in  s
 begin
    
    NTF::Condition_Notification(condition_description, condition_name);
-   
 end service;

--- a/masl/SAC/SAC_PROC/SAC_Operator_report_group.tr
+++ b/masl/SAC/SAC_PROC/SAC_Operator_report_group.tr
@@ -9,5 +9,4 @@ private service SAC::Operator~>report_group (group_name : in  string) is
 begin
    
    I_DC::info_Group(group_name);
-   
 end service;

--- a/masl/SAC/SAC_PROC/SAC_Operator_report_group_operation.tr
+++ b/masl/SAC/SAC_PROC/SAC_Operator_report_group_operation.tr
@@ -10,5 +10,4 @@ private service SAC::Operator~>report_group_operation (group_name     : in  stri
 begin
    
    I_DC::info_Group_Operation(group_name, operation_name);
-   
 end service;

--- a/masl/SAC/SAC_PROC/SAC_Operator_report_user.tr
+++ b/masl/SAC/SAC_PROC/SAC_Operator_report_user.tr
@@ -12,5 +12,4 @@ private service SAC::Operator~>report_user (user_id    : in  integer,
 begin
    
    I_DC::info_User(user_id, login_name, user_name, logged_on'image);
-   
 end service;

--- a/masl/SAC/SAC_PROC/SAC_Operator_report_user_group.tr
+++ b/masl/SAC/SAC_PROC/SAC_Operator_report_user_group.tr
@@ -12,5 +12,4 @@ private service SAC::Operator~>report_user_group (uid        : in  integer,
 begin
    
    I_DC::info_User_Group(group_name, login_name, session_id);
-   
 end service;

--- a/masl/SAC/SAC_PROC/SAC_Operator_report_user_operation.tr
+++ b/masl/SAC/SAC_PROC/SAC_Operator_report_user_operation.tr
@@ -12,5 +12,4 @@ private service SAC::Operator~>report_user_operation (user_id        : in  integ
 begin
    
    I_DC::info_User_Operation(operation_name, login_name, session_id);
-   
 end service;

--- a/masl/SAC/SAC_PROC/SAC_Operator_report_user_session.tr
+++ b/masl/SAC/SAC_PROC/SAC_Operator_report_user_session.tr
@@ -14,5 +14,4 @@ private service SAC::Operator~>report_user_session (session_id           : in  i
 begin
    
    I_DC::info_User_Session(session_id, login_time, session_timed_out, workstation_hostname, login_name);
-   
 end service;

--- a/masl/SAC/SAC_PROC/SAC_Operator_user_group_removed.tr
+++ b/masl/SAC/SAC_PROC/SAC_Operator_user_group_removed.tr
@@ -12,5 +12,4 @@ private service SAC::Operator~>user_group_removed (uid        : in  integer,
 begin
    
    I_DC::info_delete_User_Group(group_name, login_name, session_id);
-   
 end service;

--- a/masl/SAC/SAC_PROC/SAC_Operator_user_operation_removed.tr
+++ b/masl/SAC/SAC_PROC/SAC_Operator_user_operation_removed.tr
@@ -12,5 +12,4 @@ private service SAC::Operator~>user_operation_removed (user_id        : in  inte
 begin
    
    I_DC::info_delete_User_Operation(operation_name, login_name, session_id);
-   
 end service;

--- a/masl/SAC/SAC_PROC/SAC_Operator_user_removed.tr
+++ b/masl/SAC/SAC_PROC/SAC_Operator_user_removed.tr
@@ -10,5 +10,4 @@ private service SAC::Operator~>user_removed (user_id    : in  integer,
 begin
    
    I_DC::info_delete_User(login_name);
-   
 end service;

--- a/masl/SAC/SAC_PROC/SAC_Operator_user_session_deleted.tr
+++ b/masl/SAC/SAC_PROC/SAC_Operator_user_session_deleted.tr
@@ -9,5 +9,4 @@ private service SAC::Operator~>user_session_deleted (session_id : in  integer) i
 begin
    
    I_DC::info_delete_User_Session(session_id);
-   
 end service;


### PR DESCRIPTION
…aven class

This PR renames all of the MASL files in SAC_PROC to use the full names and not key letters. It also removes trailing whitespace from action bodies. This is necessary due to the issue with masldiff tracked here: https://support.onefact.net/issues/9036. The long term solution is to update masldiff to trim this whitespace for diff, however, updating the model data is a good temporary solution to produce readable diffs.