### PR TITLE
job:  #9856  Running the run_corrupt_integrity_tests.sh script is now…

### DIFF
--- a/integrity/corrupt_model_data/ExtraSubtype.expected
+++ b/integrity/corrupt_model_data/ExtraSubtype.expected
@@ -1,4 +1,4 @@
-same subtype not found across S_CDT->S_DT[R17]->S_CDT[R17]:  DT_ID "1046565f-b268-477d-9a1e-d49203519d42" 
+same subtype not found looping back across S_CDT->S_DT[R17]->S_CDT[R17]:  DT_ID "1046565f-b268-477d-9a1e-d49203519d42" 
 instances checked:  872
 checks made:  4394
 errors found:  1

--- a/integrity/corrupt_model_data/run_corrupt_integrity_tests.sh
+++ b/integrity/corrupt_model_data/run_corrupt_integrity_tests.sh
@@ -4,43 +4,43 @@ BPHOME=~/xtuml/BridgePoint
 echo "integrity tests beginning"
 
 # First run the clean model data.
-$BPHOME/tools/mc/bin/xtumlmc_build xtuml_integrity -i MWO_clean.xtuml > MWO_clean.actual
-diff -q MWO_clean.expected MWO_clean.actual || echo "failed"
+$BPHOME/tools/mc/bin/xtumlmc_build xtuml_integrity -i MWO_clean.xtuml | sort > MWO_clean.actual
+diff -q <(sort MWO_clean.expected) MWO_clean.actual || echo "failed"
 
 # Then run the (intentionally) corrupted model data.
-$BPHOME/tools/mc/bin/xtumlmc_build xtuml_integrity -i ExtraSubtype.xtuml > ExtraSubtype.actual
-diff -q ExtraSubtype.expected ExtraSubtype.actual || echo "failed"
-$BPHOME/tools/mc/bin/xtumlmc_build xtuml_integrity -i InvalidNonNullConditionalFormalizerReferential.xtuml > InvalidNonNullConditionalFormalizerReferential.actual
-diff -q InvalidNonNullConditionalFormalizerReferential.expected InvalidNonNullConditionalFormalizerReferential.actual || echo "failed"
-$BPHOME/tools/mc/bin/xtumlmc_build xtuml_integrity -i InvalidNonNullConditionalReflexiveFormalizerReferential.xtuml > InvalidNonNullConditionalReflexiveFormalizerReferential.actual
-diff -q InvalidNonNullConditionalReflexiveFormalizerReferential.expected InvalidNonNullConditionalReflexiveFormalizerReferential.actual || echo "failed"
-$BPHOME/tools/mc/bin/xtumlmc_build xtuml_integrity -i MissingAssociativeAssociator.xtuml > MissingAssociativeAssociator.actual
-diff -q MissingAssociativeAssociator.expected MissingAssociativeAssociator.actual || echo "failed"
-$BPHOME/tools/mc/bin/xtumlmc_build xtuml_integrity -i MissingAssociativeOneSide.xtuml > MissingAssociativeOneSide.actual
-diff -q MissingAssociativeOneSide.expected MissingAssociativeOneSide.actual || echo "failed"
-$BPHOME/tools/mc/bin/xtumlmc_build xtuml_integrity -i MissingAssociativeOtherSide.xtuml > MissingAssociativeOtherSide.actual
-diff -q MissingAssociativeOtherSide.expected MissingAssociativeOtherSide.actual || echo "failed"
-$BPHOME/tools/mc/bin/xtumlmc_build xtuml_integrity -i MissingSimpleFormalizer.xtuml > MissingSimpleFormalizer.actual
-diff -q MissingSimpleFormalizer.expected MissingSimpleFormalizer.actual || echo "failed"
-$BPHOME/tools/mc/bin/xtumlmc_build xtuml_integrity -i MissingSimpleParticipant.xtuml > MissingSimpleParticipant.actual
-diff -q MissingSimpleParticipant.expected MissingSimpleParticipant.actual || echo "failed"
-$BPHOME/tools/mc/bin/xtumlmc_build xtuml_integrity -i MissingSimpleReflexiveFormalizer.xtuml > MissingSimpleReflexiveFormalizer.actual
-diff -q MissingSimpleReflexiveFormalizer.expected MissingSimpleReflexiveFormalizer.actual || echo "failed"
-$BPHOME/tools/mc/bin/xtumlmc_build xtuml_integrity -i MissingSimpleReflexiveParticipant.xtuml > MissingSimpleReflexiveParticipant.actual
-diff -q MissingSimpleReflexiveParticipant.expected MissingSimpleReflexiveParticipant.actual || echo "failed"
-$BPHOME/tools/mc/bin/xtumlmc_build xtuml_integrity -i MissingSubtype.xtuml > MissingSubtype.actual
-diff -q MissingSubtype.expected MissingSubtype.actual || echo "failed"
-$BPHOME/tools/mc/bin/xtumlmc_build xtuml_integrity -i MissingSupertype.xtuml > MissingSupertype.actual
-diff -q MissingSupertype.expected MissingSupertype.actual || echo "failed"
-$BPHOME/tools/mc/bin/xtumlmc_build xtuml_integrity -i NullAssociatorReferential.xtuml > NullAssociatorReferential.actual
-diff -q NullAssociatorReferential.expected NullAssociatorReferential.actual || echo "failed"
-$BPHOME/tools/mc/bin/xtumlmc_build xtuml_integrity -i NullFormalizerReferential.xtuml > NullFormalizerReferential.actual
-diff -q NullFormalizerReferential.expected NullFormalizerReferential.actual || echo "failed"
-$BPHOME/tools/mc/bin/xtumlmc_build xtuml_integrity -i NullReflexiveFormalizerReferential.xtuml > NullReflexiveFormalizerReferential.actual
-diff -q NullReflexiveFormalizerReferential.expected NullReflexiveFormalizerReferential.actual || echo "failed"
-$BPHOME/tools/mc/bin/xtumlmc_build xtuml_integrity -i NullSubtypeReferential.xtuml > NullSubtypeReferential.actual
-diff -q NullSubtypeReferential.expected NullSubtypeReferential.actual || echo "failed"
-$BPHOME/tools/mc/bin/xtumlmc_build xtuml_integrity -i TwoInstancesWithDuplicateIdentifiers.xtuml > TwoInstancesWithDuplicateIdentifiers.actual
-diff -q TwoInstancesWithDuplicateIdentifiers.expected TwoInstancesWithDuplicateIdentifiers.actual || echo "failed"
+$BPHOME/tools/mc/bin/xtumlmc_build xtuml_integrity -i ExtraSubtype.xtuml | sort > ExtraSubtype.actual
+diff -q <(sort ExtraSubtype.expected) ExtraSubtype.actual || echo "failed"
+$BPHOME/tools/mc/bin/xtumlmc_build xtuml_integrity -i InvalidNonNullConditionalFormalizerReferential.xtuml | sort > InvalidNonNullConditionalFormalizerReferential.actual
+diff -q <(sort InvalidNonNullConditionalFormalizerReferential.expected) InvalidNonNullConditionalFormalizerReferential.actual || echo "failed"
+$BPHOME/tools/mc/bin/xtumlmc_build xtuml_integrity -i InvalidNonNullConditionalReflexiveFormalizerReferential.xtuml | sort > InvalidNonNullConditionalReflexiveFormalizerReferential.actual
+diff -q <(sort InvalidNonNullConditionalReflexiveFormalizerReferential.expected) InvalidNonNullConditionalReflexiveFormalizerReferential.actual || echo "failed"
+$BPHOME/tools/mc/bin/xtumlmc_build xtuml_integrity -i MissingAssociativeAssociator.xtuml | sort > MissingAssociativeAssociator.actual
+diff -q <(sort MissingAssociativeAssociator.expected) MissingAssociativeAssociator.actual || echo "failed"
+$BPHOME/tools/mc/bin/xtumlmc_build xtuml_integrity -i MissingAssociativeOneSide.xtuml | sort > MissingAssociativeOneSide.actual
+diff -q <(sort MissingAssociativeOneSide.expected) MissingAssociativeOneSide.actual || echo "failed"
+$BPHOME/tools/mc/bin/xtumlmc_build xtuml_integrity -i MissingAssociativeOtherSide.xtuml | sort > MissingAssociativeOtherSide.actual
+diff -q <(sort MissingAssociativeOtherSide.expected) MissingAssociativeOtherSide.actual || echo "failed"
+$BPHOME/tools/mc/bin/xtumlmc_build xtuml_integrity -i MissingSimpleFormalizer.xtuml | sort > MissingSimpleFormalizer.actual
+diff -q <(sort MissingSimpleFormalizer.expected) MissingSimpleFormalizer.actual || echo "failed"
+$BPHOME/tools/mc/bin/xtumlmc_build xtuml_integrity -i MissingSimpleParticipant.xtuml | sort > MissingSimpleParticipant.actual
+diff -q <(sort MissingSimpleParticipant.expected) MissingSimpleParticipant.actual || echo "failed"
+$BPHOME/tools/mc/bin/xtumlmc_build xtuml_integrity -i MissingSimpleReflexiveFormalizer.xtuml | sort > MissingSimpleReflexiveFormalizer.actual
+diff -q <(sort MissingSimpleReflexiveFormalizer.expected) MissingSimpleReflexiveFormalizer.actual || echo "failed"
+$BPHOME/tools/mc/bin/xtumlmc_build xtuml_integrity -i MissingSimpleReflexiveParticipant.xtuml | sort > MissingSimpleReflexiveParticipant.actual
+diff -q <(sort MissingSimpleReflexiveParticipant.expected) MissingSimpleReflexiveParticipant.actual || echo "failed"
+$BPHOME/tools/mc/bin/xtumlmc_build xtuml_integrity -i MissingSubtype.xtuml | sort > MissingSubtype.actual
+diff -q <(sort MissingSubtype.expected) MissingSubtype.actual || echo "failed"
+$BPHOME/tools/mc/bin/xtumlmc_build xtuml_integrity -i MissingSupertype.xtuml | sort > MissingSupertype.actual
+diff -q <(sort MissingSupertype.expected) MissingSupertype.actual || echo "failed"
+$BPHOME/tools/mc/bin/xtumlmc_build xtuml_integrity -i NullAssociatorReferential.xtuml | sort > NullAssociatorReferential.actual
+diff -q <(sort NullAssociatorReferential.expected) NullAssociatorReferential.actual || echo "failed"
+$BPHOME/tools/mc/bin/xtumlmc_build xtuml_integrity -i NullFormalizerReferential.xtuml | sort > NullFormalizerReferential.actual
+diff -q <(sort NullFormalizerReferential.expected) NullFormalizerReferential.actual || echo "failed"
+$BPHOME/tools/mc/bin/xtumlmc_build xtuml_integrity -i NullReflexiveFormalizerReferential.xtuml | sort > NullReflexiveFormalizerReferential.actual
+diff -q <(sort NullReflexiveFormalizerReferential.expected) NullReflexiveFormalizerReferential.actual || echo "failed"
+$BPHOME/tools/mc/bin/xtumlmc_build xtuml_integrity -i NullSubtypeReferential.xtuml | sort > NullSubtypeReferential.actual
+diff -q <(sort NullSubtypeReferential.expected) NullSubtypeReferential.actual || echo "failed"
+$BPHOME/tools/mc/bin/xtumlmc_build xtuml_integrity -i TwoInstancesWithDuplicateIdentifiers.xtuml | sort > TwoInstancesWithDuplicateIdentifiers.actual
+diff -q <(sort TwoInstancesWithDuplicateIdentifiers.expected) TwoInstancesWithDuplicateIdentifiers.actual || echo "failed"
 
 echo "integrity tests done"


### PR DESCRIPTION
… more robust.  Input expected data is sorted against actual data which is also sorted.  One expected result was changed, because the error message in integrity was given more detail.