### PR TITLE
job:#10280 Updated test model to better account for constants

### DIFF
--- a/test/scoped_path/models/scoped_path/scoped_path/Component1/PackageForClass1/Class1/Class1.xtuml
+++ b/test/scoped_path/models/scoped_path/scoped_path/Component1/PackageForClass1/Class1/Class1.xtuml
@@ -27,6 +27,14 @@ datatypesLevel = Datatypes::color::black;
 functionLevel = scoped_path::scoped_path::Functions::color::black;
 functionLevel = scoped_path::Functions::color::black;
 
+systemLevelConstant = scoped_path::scoped_path::colorConst::black;
+systemLevelConstant = scoped_path::colorConst::black;
+
+datatypesLevelConstant = Datatypes::colorConst::black;
+systemLevelConstant = datatypesLevelConstant;
+
+functionLevelConstant = scoped_path::scoped_path::Functions::colorConst::black;
+
 
 
 
@@ -34,12 +42,23 @@ functionLevel = scoped_path::Functions::color::black;
 componentLevel = Component1::PackageForClass1::color::black;
 componentLevel = scoped_path::Component1::PackageForClass1::color::black;
 componentLevel = scoped_path::scoped_path::Component1::PackageForClass1::color::black;
+componentLevelConstant = Component1::PackageForClass1::colorConst::black;
+componentLevelConstant = scoped_path::Component1::PackageForClass1::colorConst::black;
+componentLevelConstant = scoped_path::scoped_path::Component1::PackageForClass1::colorConst::black;
 
 //Test to assure the tempory types in this body are assigned correctly
 self.ThisComponentLevelEnum = componentLevel;
 self.DatatypesLevelEnum = datatypesLevel;
 self.FunctionLevelEnum = functionLevel;
 self.SystemLevelEnum = systemLevel;
+self.ThisComponentLevelConstant = componentLevelConstant;
+self.DatatypesLevelConstant = datatypesLevelConstant;
+self.FunctionLevelConstant = functionLevelConstant;
+self.SystemLevelConstant = systemLevelConstant;
+
+systemLevelConstant = datatypesLevelConstant;
+datatypesLevelConstant = systemLevelConstant;
+functionLevelConstant = datatypesLevelConstant;
 
 // Test for error:
 // Here are some error cases to assure the types are not assignable to each 
@@ -156,6 +175,78 @@ INSERT INTO S_DT_PROXY
 	'OWNER:enum3',
 	'',
 	'../PackageForClass1.xtuml');
+INSERT INTO O_NBATTR
+	VALUES ("39401573-09ea-4185-9a87-cbd83be907bc",
+	"91273e65-5bff-48ef-a105-1d49dd5c85bb");
+INSERT INTO O_BATTR
+	VALUES ("39401573-09ea-4185-9a87-cbd83be907bc",
+	"91273e65-5bff-48ef-a105-1d49dd5c85bb");
+INSERT INTO O_ATTR
+	VALUES ("39401573-09ea-4185-9a87-cbd83be907bc",
+	"91273e65-5bff-48ef-a105-1d49dd5c85bb",
+	"e6ecc8f2-3c66-4d9b-b4f3-1aeddbc94acb",
+	'SystemLevelConstant',
+	'',
+	'',
+	'SystemLevelConstant',
+	0,
+	"ba5eda7a-def5-0000-0000-000000000002",
+	'',
+	'');
+INSERT INTO O_NBATTR
+	VALUES ("85bf173d-7916-4888-8efe-b84a1ad749ab",
+	"91273e65-5bff-48ef-a105-1d49dd5c85bb");
+INSERT INTO O_BATTR
+	VALUES ("85bf173d-7916-4888-8efe-b84a1ad749ab",
+	"91273e65-5bff-48ef-a105-1d49dd5c85bb");
+INSERT INTO O_ATTR
+	VALUES ("85bf173d-7916-4888-8efe-b84a1ad749ab",
+	"91273e65-5bff-48ef-a105-1d49dd5c85bb",
+	"39401573-09ea-4185-9a87-cbd83be907bc",
+	'DatatypesLevelConstant',
+	'',
+	'',
+	'DatatypesLevelConstant',
+	0,
+	"ba5eda7a-def5-0000-0000-000000000002",
+	'',
+	'');
+INSERT INTO O_NBATTR
+	VALUES ("16f8ea17-6592-436f-8724-5b2a3efacb57",
+	"91273e65-5bff-48ef-a105-1d49dd5c85bb");
+INSERT INTO O_BATTR
+	VALUES ("16f8ea17-6592-436f-8724-5b2a3efacb57",
+	"91273e65-5bff-48ef-a105-1d49dd5c85bb");
+INSERT INTO O_ATTR
+	VALUES ("16f8ea17-6592-436f-8724-5b2a3efacb57",
+	"91273e65-5bff-48ef-a105-1d49dd5c85bb",
+	"85bf173d-7916-4888-8efe-b84a1ad749ab",
+	'FunctionLevelConstant',
+	'',
+	'',
+	'FunctionLevelConstant',
+	0,
+	"ba5eda7a-def5-0000-0000-000000000002",
+	'',
+	'');
+INSERT INTO O_NBATTR
+	VALUES ("584c0df4-03b1-427e-a7c7-2b4ea70ebaa5",
+	"91273e65-5bff-48ef-a105-1d49dd5c85bb");
+INSERT INTO O_BATTR
+	VALUES ("584c0df4-03b1-427e-a7c7-2b4ea70ebaa5",
+	"91273e65-5bff-48ef-a105-1d49dd5c85bb");
+INSERT INTO O_ATTR
+	VALUES ("584c0df4-03b1-427e-a7c7-2b4ea70ebaa5",
+	"91273e65-5bff-48ef-a105-1d49dd5c85bb",
+	"16f8ea17-6592-436f-8724-5b2a3efacb57",
+	'ThisComponentLevelConstant',
+	'',
+	'',
+	'ThisComponentLevelConstant',
+	0,
+	"ba5eda7a-def5-0000-0000-000000000002",
+	'',
+	'');
 INSERT INTO O_ID
 	VALUES (0,
 	"91273e65-5bff-48ef-a105-1d49dd5c85bb");

--- a/test/scoped_path/models/scoped_path/scoped_path/Component1/PackageForClass1/PackageForClass1.xtuml
+++ b/test/scoped_path/models/scoped_path/scoped_path/Component1/PackageForClass1/PackageForClass1.xtuml
@@ -80,7 +80,7 @@ INSERT INTO GD_GE
 	"2d758fd6-ab53-4eaa-9b75-cc0af0eab1b8",
 	109,
 	0,
-	'scoped_path::scoped_path::Component1::PackageForClass1::color');
+	'scoped_path::scoped_path::Component1::PackageForClass1::colorConst');
 INSERT INTO GD_SHP
 	VALUES ("5c757168-b654-4338-93fa-db7f36b8d120");
 INSERT INTO GD_NCS
@@ -169,7 +169,7 @@ INSERT INTO PE_PE
 	3);
 INSERT INTO CNST_CSP
 	VALUES ("2d758fd6-ab53-4eaa-9b75-cc0af0eab1b8",
-	'color',
+	'colorConst',
 	'');
 INSERT INTO CNST_SYC
 	VALUES ("2ca1fab1-2e80-487f-821c-47b9396d8c6d",

--- a/test/scoped_path/models/scoped_path/scoped_path/Datatypes/Datatypes.xtuml
+++ b/test/scoped_path/models/scoped_path/scoped_path/Datatypes/Datatypes.xtuml
@@ -80,7 +80,7 @@ INSERT INTO GD_GE
 	"87d69da9-182e-44ff-b764-809415c865ea",
 	109,
 	0,
-	'scoped_path::scoped_path::Datatypes::color');
+	'scoped_path::scoped_path::Datatypes::colorConst');
 INSERT INTO GD_SHP
 	VALUES ("50e0a0c5-b8e0-49d9-9f71-7d50ad012eda");
 INSERT INTO GD_NCS
@@ -186,7 +186,7 @@ INSERT INTO PE_PE
 	3);
 INSERT INTO CNST_CSP
 	VALUES ("87d69da9-182e-44ff-b764-809415c865ea",
-	'color',
+	'colorConst',
 	'');
 INSERT INTO CNST_SYC
 	VALUES ("82fb2d91-9934-48da-8720-5aa69987b3a8",

--- a/test/scoped_path/models/scoped_path/scoped_path/Enumeration Four/Initialization Object/InstanceStateMachine/InstanceStateMachine.xtuml
+++ b/test/scoped_path/models/scoped_path/scoped_path/Enumeration Four/Initialization Object/InstanceStateMachine/InstanceStateMachine.xtuml
@@ -74,19 +74,38 @@ datatypesLevel = Datatypes::color::black;
 functionLevel = scoped_path::scoped_path::Functions::color::black;
 functionLevel = scoped_path::Functions::color::black;
 
+systemLevelConstant = scoped_path::scoped_path::colorConst::black;
+systemLevelConstant = scoped_path::colorConst::black;
+
+datatypesLevelConstant = Datatypes::colorConst::black;
+systemLevelConstant = datatypesLevelConstant;
+
+functionLevelConstant = scoped_path::scoped_path::Functions::colorConst::black;
+
 // Test for error:
 // Note that scoping rules prevent the item(s) under a package from 
-// being visible, so "MyPackage", at this scope is flagged as an error.
+// being visible, so "PackageForClass1", at this scope is flagged as an error.
 //
 //componentLevel = Component1::PackageForClass1::color::black;
 //componentLevel = scoped_path::Component1::PackageForClass1::color::black;
 //componentLevel = scoped_path::scoped_path::Component1::PackageForClass1::color::black;
+//componentLevelConstant = Component1::PackageForClass1::colorConst::black;
+//componentLevelConstant = scoped_path::Component1::PackageForClass1::colorConst::black;
+//componentLevelConstant = scoped_path::scoped_path::Component1::PackageForClass1::colorConst::black;
 
 
 
 
 
 
+
+
+
+
+
+systemLevelConstant = datatypesLevelConstant;
+datatypesLevelConstant = systemLevelConstant;
+functionLevelConstant = datatypesLevelConstant;
 
 // Test for error:
 // Here are some error cases to assure the types are not assignable to each 
@@ -95,7 +114,7 @@ functionLevel = scoped_path::Functions::color::black;
 //systemLevel = datatypesLevel;
 //datatypesLevel = systemLevel;
 //functionLevel = datatypesLevel;
-//datatypesLevel = conponentLevel;
+//datatypesLevel = componentLevel;
 
 
 ',

--- a/test/scoped_path/models/scoped_path/scoped_path/Functions/Functions.xtuml
+++ b/test/scoped_path/models/scoped_path/scoped_path/Functions/Functions.xtuml
@@ -56,7 +56,7 @@ INSERT INTO GD_GE
 	"63cd7e22-a53e-41e5-8cd1-bd54ef032c67",
 	109,
 	0,
-	'scoped_path::scoped_path::Functions::color');
+	'scoped_path::scoped_path::Functions::colorConst');
 INSERT INTO GD_SHP
 	VALUES ("00b36ace-d46e-47b6-863e-2446b2c4890e");
 INSERT INTO GD_NCS
@@ -145,7 +145,7 @@ INSERT INTO PE_PE
 	3);
 INSERT INTO CNST_CSP
 	VALUES ("63cd7e22-a53e-41e5-8cd1-bd54ef032c67",
-	'color',
+	'colorConst',
 	'');
 INSERT INTO CNST_SYC
 	VALUES ("96e7e84b-dfb2-433b-8553-3ceaf2ac3035",

--- a/test/scoped_path/models/scoped_path/scoped_path/scoped_path.xtuml
+++ b/test/scoped_path/models/scoped_path/scoped_path/scoped_path.xtuml
@@ -176,7 +176,7 @@ INSERT INTO GD_GE
 	"bd56c518-5b00-4099-a146-02620c0d0d08",
 	109,
 	0,
-	'scoped_path::scoped_path::color');
+	'scoped_path::scoped_path::colorConst');
 INSERT INTO GD_SHP
 	VALUES ("c77b6d2d-43fb-4057-8e5d-98d3163cd545");
 INSERT INTO GD_NCS
@@ -265,7 +265,7 @@ INSERT INTO PE_PE
 	3);
 INSERT INTO CNST_CSP
 	VALUES ("bd56c518-5b00-4099-a146-02620c0d0d08",
-	'color',
+	'colorConst',
 	'');
 INSERT INTO CNST_SYC
 	VALUES ("d848cec2-82a6-4979-9ce0-025148db1d62",


### PR DESCRIPTION
Previously the model had the enumeration and constant specification use
the same name. That actually caused us to miss the headline issue in the
testing (#10280). This change allows us to better test this situation.