### PR TITLE
job:  #11414  Previous commit corrupted a couple of files with CRLFs.…

### DIFF
--- a/masl/SWATS/Function_Calls/objB_Verification.al
+++ b/masl/SWATS/Function_Calls/objB_Verification.al
@@ -160,7 +160,8 @@ state Function_Calls::Object_B.Verification (Test_Case_ID : in  integer,
       # Check that the function performed its task correctly
       if (this.ResultA != 10) then
         [] = RPT3:Test_Failed["objB", Test_Case_ID, -5]
-       has_failed = TRUE
+
+has_failed = TRUE
         generate objB1:Fault() to this
      else
         temp = this.ResultA + 10

--- a/masl/SWATS/Relationships/M_Middle_Navigation.svc
+++ b/masl/SWATS/Relationships/M_Middle_Navigation.svc
@@ -449,12 +449,14 @@ Has_Failed = FALSE
             if Inst.Above_Data = 1 then
                [] = RPT2:Test_Passed ["Single Instance to Single Instance M to MR to MA", Test, Inst.Above_Data]
             else
-              [] = RPT3:Test_Failed ["Single Instance to Single Instance M to MR to MA", Test, Inst.Above_Data]
+      
+        [] = RPT3:Test_Failed ["Single Instance to Single Instance M to MR to MA", Test, Inst.Above_Data]
             endif
          endfor
 
       else
-        [] = RPT3:Test_Failed ["Single Instance to Single Instance M to MR to MA", Test, NoInSet]
+
+        [] = RPT3:Test_Failed ["Single Instance to Single Instance M to MR to MA", Test, NoInSet]
       endif
 
 }#


### PR DESCRIPTION
…  A couple of the CRLF were in the middle of a line (incomplete CRLF).  This caused MASL parse errors.