### PR TITLE
Corrected forward type references

### DIFF
--- a/masl/SWATS/OAIBONE/OAIBONE.mod
+++ b/masl/SWATS/OAIBONE/OAIBONE.mod
@@ -13,6 +13,10 @@ domain OAIBONE is
     The_VSD_IH : instance of Very_Simple_Data_Object;
   end structure;
 
+  public type Colour_Type is enum (Red,
+                                   Green,
+                                   Blue);
+
   public type Source_Structure_Type is structure
     Source_Integer : integer;
     Source_Real    : real;
@@ -21,9 +25,7 @@ domain OAIBONE is
     Source_Colour  : Colour_Type;
   end structure;
 
-  public type Colour_Type is enum (Red,
-                                   Green,
-                                   Blue);
+  private type Pos is integer; pragma type_range(1,10);
 
   public type Structure_Of_UDTs is structure
     The_Range : Pos;
@@ -34,8 +36,6 @@ domain OAIBONE is
     Int_Type  : integer;
     Real_Type : real;
   end structure;
-
-  private type Pos is integer; pragma type_range(1,10);
 
   public service Receive_A_Very_Simple_Structure (Received_Very_Simple_Structure : in  sequence of Very_Simple_Structure_Type,
                                                   Received_Control_Integer       : in  integer,

--- a/masl/SWATS/OAIBTWO/OAIBTWO.mod
+++ b/masl/SWATS/OAIBTWO/OAIBTWO.mod
@@ -2,6 +2,10 @@ domain OAIBTWO is
   object I_Into_The_Great_Wide_Open;
   object Report_Data;
 
+  public type Colour_Type is enum (Red,
+                                   Green,
+                                   Blue);
+
   public type Source_Structure_Type is structure
     Source_Integer : integer;
     Source_Real    : real;
@@ -9,10 +13,6 @@ domain OAIBTWO is
     Source_Boolean : boolean;
     Source_Colour  : Colour_Type;
   end structure;
-
-  public type Colour_Type is enum (Red,
-                                   Green,
-                                   Blue);
 
   public type Very_Simple_Source_Structure_Type is structure
     Source_Simple_Integer : integer;

--- a/masl/SWATS/SBONE/SBONE.mod
+++ b/masl/SWATS/SBONE/SBONE.mod
@@ -13,6 +13,10 @@ domain SBONE is
     The_VSD_IH : instance of Very_Simple_Data_Object;
   end structure;
 
+  public type Colour_Type is enum (Red,
+                                   Green,
+                                   Blue);
+
   public type Source_Structure_Type is structure
     Source_Integer : integer;
     Source_Real    : real;
@@ -21,9 +25,7 @@ domain SBONE is
     Source_Colour  : Colour_Type;
   end structure;
 
-  public type Colour_Type is enum (Red,
-                                   Green,
-                                   Blue);
+  private type Pos is integer; pragma type_range(1,10);
 
   public type Structure_Of_UDTs is structure
     The_Range : Pos;
@@ -34,8 +36,6 @@ domain SBONE is
     Int_Type  : integer;
     Real_Type : real;
   end structure;
-
-  private type Pos is integer; pragma type_range(1,10);
 
   public service Receive_A_Very_Simple_Structure (Received_Very_Simple_Structure : in  sequence of Very_Simple_Structure_Type,
                                                   Received_Control_Integer       : in  integer,

--- a/masl/SWATS/SBTWO/SBTWO.mod
+++ b/masl/SWATS/SBTWO/SBTWO.mod
@@ -1,6 +1,10 @@
 domain SBTWO is
   object Report_Data;
 
+  public type Colour_Type is enum (Red,
+                                   Green,
+                                   Blue);
+
   public type Source_Structure_Type is structure
     Source_Integer : integer;
     Source_Real    : real;
@@ -8,10 +12,6 @@ domain SBTWO is
     Source_Boolean : boolean;
     Source_Colour  : Colour_Type;
   end structure;
-
-  public type Colour_Type is enum (Red,
-                                   Green,
-                                   Blue);
 
   public type Very_Simple_Source_Structure_Type is structure
     Source_Simple_Integer : integer;

--- a/masl/SWATS/Struct/Struct.mod
+++ b/masl/SWATS/Struct/Struct.mod
@@ -5,6 +5,10 @@ domain Struct is
   object Report_Data;
   object Test_Data;
 
+  public type Colour_Type is enum (Red,
+                                   Green,
+                                   Blue);
+
   public type Simple_Structure_Type is structure
     S_Integer : integer;
     S_Real    : real;
@@ -27,9 +31,9 @@ domain Struct is
     A_Boolean  : boolean;
   end structure;
 
-  public type First_Nested_Structure_Type is structure
-    Second_Nested_Structure : sequence of Second_Nested_Structure_Type;
-    First_Nested_Integer    : integer;
+  public type Third_Nested_Structure_Type is structure
+    Third_Nested_Integer : integer;
+    The_Holy_Grail       : Colour_Type;
   end structure;
 
   public type Second_Nested_Structure_Type is structure
@@ -37,14 +41,10 @@ domain Struct is
     Third_Nested_Integer   : integer;
   end structure;
 
-  public type Third_Nested_Structure_Type is structure
-    Third_Nested_Integer : integer;
-    The_Holy_Grail       : Colour_Type;
+  public type First_Nested_Structure_Type is structure
+    Second_Nested_Structure : sequence of Second_Nested_Structure_Type;
+    First_Nested_Integer    : integer;
   end structure;
-
-  public type Colour_Type is enum (Red,
-                                   Green,
-                                   Blue);
 
   public type Structure_and_IH_Type is structure
     A_Defined_IH : instance of Structured_Object;
@@ -62,15 +62,15 @@ domain Struct is
     Col_Val    : Colour_Type;
   end structure;
 
+  private type UDT_Integer_Type is integer; pragma type_range(0,100);
+
+  private type UDT_Real_Type is real; pragma type_range(0.0,100.0);
+
   //! This structure shall contain user defined types.
   private type UDT_Structure_Type is structure
     An_Integer : UDT_Integer_Type;
     A_Real     : UDT_Real_Type;
   end structure;
-
-  private type UDT_Integer_Type is integer; pragma type_range(0,100);
-
-  private type UDT_Real_Type is real; pragma type_range(0.0,100.0);
 
   //! This structure shall contain a structure, a couple of user 
   //! defined types and a simple integer base type.
@@ -84,14 +84,14 @@ domain Struct is
     A_Colour        : Colour_Type;
   end structure;
 
+  private type Alternative_Colour_Type is enum (Red,
+                                                Pink,
+                                                Puce);
+
   private type Different_Structure_Type is structure
     Alternative_Colour : Alternative_Colour_Type;
     Extra_Member       : integer;
   end structure;
-
-  private type Alternative_Colour_Type is enum (Red,
-                                                Pink,
-                                                Puce);
 
   private type Multiple_Structures_Type is structure
     Initial_Structure     : sequence of First_Nested_Structure_Type;


### PR DESCRIPTION
Corrected type ordering in MASL .mod files for
OAIBONE
OAIDTWO
SBONE
SBTWO
STRUCT